### PR TITLE
"Big" scroll and new key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ This project is an [Atom](http://atom.io/) package.
 
 It's meant to reproduce the Line Up/Down functionality of [Sublime](http://www.sublimetext.com/) and SCI_LINESCROLLUP/DOWN functionality from [Notepad++](http://notepad-plus-plus.org/)
 
-The desired behaviour is to have Ctrl-Up (Ctrl-Alt-Up on Mac, Linux) scroll the page a single line up, leaving the cursor in place.
-When the cursor reaches the end of the page, it should scroll a single line as well to prevent it moving off the page.
-The same should happen for Ctrl-Down (Ctrl-Alt-Up on Mac, Linux) but in the opposite direction.
+The desired behaviour is to have `Ctrl-Up` (`Ctrl-Alt-Up` on Mac) scroll the page a single line up, leaving the cursor in place.
+The same should happen for `Ctrl-Down` (`Ctrl-Alt-Up` on Mac) but in the opposite direction.
+
+You can also use `Ctrl-Shift-Up/Down` (`Ctrl-Alt-Shift-Up/Down` on Mac) to move 10 lines at a time (amount of lines configurable).
+
+When the cursor reaches the end of the page, it should scroll a single line as well to prevent it moving off the page (this can be disabled in settings).
+
+Also have a look at [line-jumper](https://atom.io/packages/line-jumper) which allows you to move the cursor 10 lines at a time.
 
 Atom version 1.0 compliant thanks to [harai](https://github.com/harai)
+

--- a/keymaps/ctrl-dir-scroll.cson
+++ b/keymaps/ctrl-dir-scroll.cson
@@ -11,15 +11,18 @@
 '.platform-darwin atom-workspace atom-text-editor:not(.mini)':
   'ctrl-alt-up': 'ctrl-dir-scroll:scroll-up'
   'ctrl-alt-down': 'ctrl-dir-scroll:scroll-down'
+  'ctrl-alt-shift-up': 'ctrl-dir-scroll:scroll-up-big'
+  'ctrl-alt-shift-down': 'ctrl-dir-scroll:scroll-down-big'
 
 '.platform-linux atom-workspace atom-text-editor:not(.mini)':
-  'ctrl-alt-up': 'ctrl-dir-scroll:scroll-up'
-  'ctrl-alt-down': 'ctrl-dir-scroll:scroll-down'
+  'ctrl-up': 'ctrl-dir-scroll:scroll-up'
+  'ctrl-down': 'ctrl-dir-scroll:scroll-down'
+  'ctrl-shift-up': 'ctrl-dir-scroll:scroll-up-big'
+  'ctrl-shift-down': 'ctrl-dir-scroll:scroll-down-big'
 
 '.platform-win32 atom-workspace atom-text-editor:not(.mini)':
   'ctrl-up': 'ctrl-dir-scroll:scroll-up'
   'ctrl-down': 'ctrl-dir-scroll:scroll-down'
+  'ctrl-shift-up': 'ctrl-dir-scroll:scroll-up-big'
+  'ctrl-shift-down': 'ctrl-dir-scroll:scroll-down-big'
 
-#'body':
-#  'ctrl-shift-up': 'editor:move-line-up'
-#  'ctrl-shift-down': 'editor:move-line-down'

--- a/lib/ctrl-dir-scroll.coffee
+++ b/lib/ctrl-dir-scroll.coffee
@@ -1,32 +1,59 @@
 module.exports =
+  config:
+    keepCursorInView:
+      type: 'boolean'
+      default: true
+      description: 'Keep the cursor a few lines wihin the screen'
+      order: 1
+    bigScrollSize:
+      type: 'integer'
+      default: 10
+      minimum: 1
+      maximum: 1000
+      description: 'Number of lines to move on a "big" scroll'
+      order: 2
+
   activate: (state) ->
-    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-up", => @scrollUp()
-    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-down", => @scrollDown()
+    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-up", =>
+      @scrollUp(1)
+    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-up-big", =>
+      @scrollUp(atom.config.get 'ctrl-dir-scroll.bigScrollSize')
+    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-down", =>
+      @scrollDown(1)
+    atom.commands.add 'atom-workspace', "ctrl-dir-scroll:scroll-down-big", =>
+      @scrollDown(atom.config.get 'ctrl-dir-scroll.bigScrollSize')
 
-  scrollUp: ->
+  scrollUp: (amount) ->
     editor = atom.workspace.getActiveTextEditor()
     if (editor)
-      # editor.getVisibleRowRange()[0] ignores the blank line on the end which causes cursor correction to behave in an
-      # undesirable manner.
-      calculatedLastRow = Math.ceil(editor.getScrollBottom() / editor.getLineHeightInPixels()) - 1
+      keepCursorInView = atom.config.get 'ctrl-dir-scroll.keepCursorInView'
+      for i in [1..amount]
+        # editor.getVisibleRowRange()[0] ignores the blank line on the end which causes cursor correction to behave in an
+        # undesirable manner.
+        calculatedLastRow = Math.ceil(editor.getScrollBottom() / editor.getLineHeightInPixels()) - 1
 
-      # Check if the cursor is beyond the end of the page. If it is then move it up one line
-      # The default behaviour of the editor is to keep the cursor a couple of lines within the screen. We are replicating that.
-      while ((editor.getCursorScreenPosition().row + 2) >= calculatedLastRow)
-        editor.moveUp(1)
+        if keepCursorInView
+          # Check if the cursor is beyond the end of the page. If it is then move it up one line
+          # The default behaviour of the editor is to keep the cursor a couple of lines within the screen. We are replicating that.
+          while ((editor.getCursorScreenPosition().row + 2) >= calculatedLastRow)
+            editor.moveUp(1)
 
-      # Scroll the editor by one lines worth of pixels
-      editor.setScrollTop(editor.getScrollTop() - editor.getLineHeightInPixels())
+        # Scroll the editor by one lines worth of pixels
+        editor.setScrollTop(editor.getScrollTop() - editor.getLineHeightInPixels())
 
-  scrollDown: ->
+  scrollDown: (amount) ->
     editor = atom.workspace.getActiveTextEditor()
     if (editor)
-      # Check if the cursor is beyond the end of the page. If it is then move it up one line
-      # The default behaviour of the editor is to keep the cursor a couple of lines within the screen. We are replicating that.
-      prevRow = editor.getCursorScreenPosition().row - 1
-      while (((editor.getCursorScreenPosition().row - 2) <= editor.getVisibleRowRange()[0]) && (editor.getCursorScreenPosition().row != prevRow))
-        prevRow = editor.getCursorScreenPosition().row
-        editor.moveDown(1)
+      keepCursorInView = atom.config.get 'ctrl-dir-scroll.keepCursorInView'
+      for i in [1..amount]
+        if keepCursorInView
+          # Check if the cursor is beyond the end of the page. If it is then move it up one line
+          # The default behaviour of the editor is to keep the cursor a couple of lines within the screen. We are replicating that.
+          prevRow = editor.getCursorScreenPosition().row - 1
+          while (((editor.getCursorScreenPosition().row - 2) <= editor.getVisibleRowRange()[0]) && (editor.getCursorScreenPosition().row != prevRow))
+            prevRow = editor.getCursorScreenPosition().row
+            editor.moveDown(1)
 
-      # Scroll the editor by one lines worth of pixels
-      editor.setScrollTop(editor.getScrollTop() + editor.getLineHeightInPixels())
+        # Scroll the editor by one lines worth of pixels
+        editor.setScrollTop(editor.getScrollTop() + editor.getLineHeightInPixels())
+


### PR DESCRIPTION
The current Linux key bindings don't work in most desktop environments (Unity, Gnome, etc.), because they are used for switching workspaces. These are now the same as on Windows (`Ctrl-up` and `Ctrl-down`).

I would also like to change the default OS X key bindings (so that they would be the same across platforms), but these have to be confirmed not to conflict with anything else. I can check this next week, unless someone else reports on this sooner.

This pull request also has a new "big" scroll feature, which is bound to `Ctrl-Shift-up/down` (`Ctrl-Alt-Shift-up/down` on OS X). It scrolls 10 lines at a time, which is extremely useful for long files. The amount of lines to scroll can be changed in the package's settings. Now this package and [line-jumper](https://atom.io/packages/line-jumper) are a perfect match. :)

*Also in this pull request* is the ability to configure whether you want to keep the cursor on the screen. Personally, I don't, because I essentially want this package to behave like mouse scrolling (without the mouse).

Sorry for putting 3 different things into one pull request, I can split this up if you don't want to merge something.